### PR TITLE
update brew install command

### DIFF
--- a/kickstart.sh
+++ b/kickstart.sh
@@ -30,7 +30,7 @@ echo
 # Install homebrew
 echo "🔨 Installing homebrew..."
 echo
-/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
 brew tap homebrew/cask-versions
 
 # Install proper terminal - iterm2 and oh-my-zsh


### PR DESCRIPTION
executing the current command gives the following migration guidelines:

```Warning: The Ruby Homebrew installer is now deprecated and has been rewritten in
Bash. Please migrate to the following command:
  /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install.sh)"
```